### PR TITLE
Fix port mapping syntax in Docker run command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ docker build -t insecure_deserialize:latest .
 ## Running
 
 ```
-docker run -d insecure_deserialize:latest -p 33322:80
+docker run -d -p 33322:80 insecure_deserialize:latest
 ```
 
 ## Exploting


### PR DESCRIPTION
## Description:

Context or Background:
Noticed an incorrect arrangement of options in the docker run command in the README.md, which could lead to confusion and unsuccessful container deployment.

## Changes Made:

Corrected the order of the -d and -p flags in the docker run command.
Fixed the port mapping syntax to correctly map the host's port 33322 to the container's port 80.
Impact:
The corrected command in the README.md will now work as intended, facilitating users in correctly running the container without encountering port mapping issues.

## Additional Notes:
Please ensure the specified host port (33322) does not conflict with other services on the host machine.